### PR TITLE
StdのIteratorの実装の変更に対応

### DIFF
--- a/tests/crypto/secure_random_test.fix
+++ b/tests/crypto/secure_random_test.fix
@@ -70,7 +70,7 @@ test_container = (
         secure_random: *SecureRandom::make
     };
     let container: Container = *do {
-        mod_state(set_title("started"));;
+        State::mod_state(set_title("started"));;
         let container: Container = *get_state;
         assert_equal("title", "started", container.@title).lift_iofail;;
         let u64_a: U64 = *random_U64;
@@ -78,7 +78,7 @@ test_container = (
         println("u64:" + (u64_a, u64_b).to_string).lift_io;;
         // If equal accidentally, change random seed
         assert_true("u64", u64_a != u64_b).lift_iofail;;
-        mod_state(set_title("finished"));;
+        State::mod_state(set_title("finished"));;
         pure()
     }.exec_state_t(container);
     assert_equal("title", "finished", container.@title);;

--- a/tests/monad/free_random_test.fix
+++ b/tests/monad/free_random_test.fix
@@ -16,24 +16,24 @@ type Item = unbox struct {
     bytes: Array U8,
 };
 
-impl Item: ToString {
+impl FreeRandomTest::Item: ToString {
     to_string = |item| "Item" + (item.@u64, item.@bytes).to_string;
 }
 
-generate_item: [m: MonadRandom] m Item;
+generate_item: [m: MonadRandom] m FreeRandomTest::Item;
 generate_item = (
-    pure $ Item {
+    pure $ FreeRandomTest::Item {
         u64: *random_U64,
         bytes: *random_bytes(4),
     }
 );
 
-generate_items: [m: MonadRandom] I64 -> m (Array Item);
+generate_items: [m: MonadRandom] I64 -> m (Array FreeRandomTest::Item);
 generate_items = |size| (
     Iterator::range(0, size).to_array.map_m(|i| generate_item)
 );
 
-my_items: FreeRandom (Array Item);
+my_items: FreeRandom (Array FreeRandomTest::Item);
 my_items = generate_items(5);
 
 test_free_random: TestCase;

--- a/tests/monad/monad_random_test.fix
+++ b/tests/monad/monad_random_test.fix
@@ -152,7 +152,7 @@ test_container = (
         random: Random::init_by_seed(123_U64)
     };
     let container: Container = *do {
-        mod_state(set_title("started"));;
+        State::mod_state(set_title("started"));;
         let container: Container = *get_state;
         assert_equal("title", "started", container.@title).lift_iofail;;
         let u64_a: U64 = *random_U64;
@@ -160,7 +160,7 @@ test_container = (
         println("u64:" + (u64_a, u64_b).to_string).lift_io;;
         // If equal accidentally, change random seed
         assert_true("u64", u64_a != u64_b).lift_iofail;;
-        mod_state(set_title("finished"));;
+        State::mod_state(set_title("finished"));;
         pure()
     }.exec_state_t(container);
     assert_equal("title", "finished", container.@title);;

--- a/tests/random/xor_shift_test.fix
+++ b/tests/random/xor_shift_test.fix
@@ -76,7 +76,7 @@ test_container = (
         xor_shift: XorShift::init_by_seed(12345_U64)
     };
     let container: Container = *do {
-        mod_state(set_title("started"));;
+        State::mod_state(set_title("started"));;
         let container: Container = *get_state;
         assert_equal("title", "started", container.@title).lift_iofail;;
         let u64_a: U64 = *random_U64;
@@ -84,7 +84,7 @@ test_container = (
         println("u64:" + (u64_a, u64_b).to_string).lift_io;;
         // If equal accidentally, change random seed
         assert_true("u64", u64_a != u64_b).lift_iofail;;
-        mod_state(set_title("finished"));;
+        State::mod_state(set_title("finished"));;
         pure()
     }.exec_state_t(container);
     assert_equal("title", "finished", container.@title);;


### PR DESCRIPTION
StdのIteratorの実装の変更に対応しました。

・stateというフィールドを持つ構造体がStdに追加されたことで、テストコード中のmod_stateの名前空間が推論できなくなってしまいましたので、名前空間を追加しました。
Fixはより前に書かれている式の型情報をもとに名前の名前空間を推論します（x.fという式なら、xの型を使ってfの名前空間を推論することができます）が、doの先頭にある式の名前空間を推論するのは難しいようです。

・Itemという型についても、Iterator::Itemと衝突してしまったので名前空間を追加しています。これについては、import Std hiding Iterator::Itemで対処しようとしたのですが、うまく動作しませんでした。こちらはコンパイラの問題ではあるので、後ほど調査しようと思います。